### PR TITLE
executeSELECTION: Unload empty tables.

### DIFF
--- a/src/executors/selection.cpp
+++ b/src/executors/selection.cpp
@@ -132,6 +132,7 @@ void executeSELECTION()
         tableCatalogue.insertTable(resultantTable);
     else{
         cout<<"Empty Table"<<endl;
+        resultantTable->unload();
         delete resultantTable;
     }
     return;


### PR DESCRIPTION
## Bug Description
Empty temporary tables are never unloaded, which causes their source CSV file to persist. If such a table name is reused, it causes the new table's contents to be appended to the original CSV, causing parsing problems while the table is being blockified.

![broken](https://user-images.githubusercontent.com/43912285/95666463-7bbe1280-0b77-11eb-993d-3761bb31a144.png)

## Fix
The fix is to unload the `resultantTable` before deleting the associated memory in `executeSELECTION`.

![fixed](https://user-images.githubusercontent.com/43912285/95666479-9abca480-0b77-11eb-8c0f-38eab6c9292f.png)


Bug found by: @shanmukh1608 
Bug fix suggested by: @jiviteshjain