### PR TITLE
syntacticParseSORT: Fixed order of parsing

### DIFF
--- a/src/executors/sort.cpp
+++ b/src/executors/sort.cpp
@@ -15,12 +15,12 @@ bool syntacticParseSORT(){
     }
     parsedQuery.queryType = SORT;
     parsedQuery.sortResultRelationName = tokenizedQuery[0];
-    parsedQuery.sortColumnName = tokenizedQuery[3];
-    parsedQuery.sortRelationName = tokenizedQuery[5];
-    string sortingStrateg = tokenizedQuery[7];
-    if(sortingStrateg == "ASC")
+    parsedQuery.sortRelationName = tokenizedQuery[3];
+    parsedQuery.sortColumnName = tokenizedQuery[5];
+    string sortingStrategy = tokenizedQuery[7];
+    if(sortingStrategy == "ASC")
         parsedQuery.sortingStrategy = ASC;
-    else if(sortingStrateg == "DESC")
+    else if(sortingStrategy == "DESC")
         parsedQuery.sortingStrategy = DESC;
     else{
         cout<<"SYNTAX ERROR"<<endl;


### PR DESCRIPTION
### Bug Description
The syntax for sort is `R <- SORT relation_name BY column_name IN sorting_order`. However, the syntacticParseSORT function was storing the `column_name` in `parsedQuery.sortRelationName`, and `relation_name` in `parsedQuery.sortColumnName`. 

Also, there was a minor typo where sortingStrategy was spelt as sortingStrateg.

### Fix
The fix was to store `column_name` in `parsedQuery.sortColumnName`, and `relation_name` in `parsedQuery.sortRelationName`. Also, sortingStrateg was renamed to sortingStrategy.
